### PR TITLE
204/304 response should also trigger onDoneEnumerating for the body

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -168,6 +168,8 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
               data = dataSource(enum)
             ))
           case ServerResultUtils.StreamWithNoBody =>
+            // Ensure that the body is consumed in case any onDoneEnumerating handlers are registered
+            result.body |>>> Iteratee.ignore
             valid(HttpEntity.Empty)
           case ServerResultUtils.StreamWithKnownLength(enum) =>
             convertedHeaders.contentLength.get match {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -4,11 +4,13 @@
 package play.it.http
 
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
 import play.api.mvc._
 import play.api.test._
 import play.api.libs.ws._
 import play.api.libs.iteratee._
 import play.it._
+import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.{ Failure, Success, Try }
 import play.api.libs.concurrent.Execution.{ defaultContext => ec }
 import play.api.http.Status
@@ -350,5 +352,61 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         response.status must_== Status.INTERNAL_SERVER_ERROR
         (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be(Map.empty)
       }
+
+    "trigger onDoneEnumerating when a repsonse with a non-empty body completes" in {
+      val triggered = new AtomicBoolean(false)
+      withServer {
+        val ret = Results.Ok("Result with some body")
+        ret.copy(body = ret.body.onDoneEnumerating(triggered.set(true)))
+      } { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )(0)
+        response.status must_== 200
+        triggered.get must_== true
+      }
+    }
+
+    "trigger onDoneEnumerating when a repsonse with an empty body completes" in {
+      val triggered = new AtomicBoolean(false)
+      withServer {
+        val ret = Results.Ok
+        ret.copy(body = ret.body.onDoneEnumerating(triggered.set(true)))
+      } { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )(0)
+        response.status must_== 200
+        triggered.get must_== true
+      }
+    }
+
+    "trigger onDoneEnumerating when a 204 repsonse completes" in {
+      val triggered = new AtomicBoolean(false)
+      withServer {
+        val ret = Results.NoContent
+        ret.copy(body = ret.body.onDoneEnumerating(triggered.set(true)))
+      } { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )(0)
+        response.status must_== 204
+        triggered.get must_== true
+      }
+    }
+
+    "trigger onDoneEnumerating when a 304 repsonse completes" in {
+      val triggered = new AtomicBoolean(false)
+      withServer {
+        val ret = Results.NotModified
+        ret.copy(body = ret.body.onDoneEnumerating(triggered.set(true)))
+      } { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )(0)
+        response.status must_== 304
+        triggered.get must_== true
+      }
+    }
   }
 }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
@@ -87,7 +87,8 @@ object NettyResultStreamer {
             case ServerResultUtils.StreamWithKnownLength(enum) =>
               streamEnum(enum)
             case ServerResultUtils.StreamWithNoBody =>
-              // `StreamWithNoBody` won't add the Content-Length entity-header to the response (if not already present)
+              // Ensure that the body is consumed in case any onDoneEnumerating handlers are registered
+              result.body |>>> Iteratee.ignore
               sendContent()
             case ServerResultUtils.StreamWithStrictBody(body) =>
               // We successfully buffered it, so set the content length and send the whole thing as one buffer


### PR DESCRIPTION
When the response status is 204 or 304, the response doesn't send out with a body. The case of StreamWithNoBody in both Netty server and Akka HTTP server didn't consume the response's empty Enumerator body, thus the onDoneEnumerating hook couldn't be triggered.

Create this pull request on behalf of @bbarkley.