### PR TITLE
Removes final class attribution from ServerCookieEncoder.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   # Define scripts here so they run concurrently
   - SCRIPT=codeChecks

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ServerCookieEncoder.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ServerCookieEncoder.java
@@ -33,7 +33,7 @@ import java.util.List;
  *
  * @see ServerCookieDecoder
  */
-public final class ServerCookieEncoder extends CookieEncoder {
+public class ServerCookieEncoder extends CookieEncoder {
 
     /**
      * Strict encoder that validates that name and value chars are in the valid scope


### PR DESCRIPTION
In order to allow the Same-site cookie attribute for 2.4 users, allow
ServerCookieEncoder to be extended so a different ServerCookieEncoder
can be injected.