### PR TITLE
Bump jjwt to latest

### DIFF
--- a/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -85,7 +85,7 @@ class HttpErrorHandlerSpec extends Specification {
   def handler(handlerClass: String, mode: Mode): HttpErrorHandler = {
     val properties = Map(
       "play.http.errorHandler" -> handlerClass,
-      "play.http.secret.key"   -> "mysecret"
+      "play.http.secret.key"   -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"
     )
     val config            = ConfigFactory.parseMap(properties.asJava).withFallback(ConfigFactory.defaultReference())
     val configuration     = Configuration(config)

--- a/core/play-integration-test/src/test/resources/application.conf
+++ b/core/play-integration-test/src/test/resources/application.conf
@@ -1,7 +1,7 @@
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 
 # Play sometimes gets grumpy if this file doesn't exist.
-play.http.secret.key = "abc"
+play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
 
 # Set no filters by default
 play.filters.enabled=[]

--- a/core/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -90,7 +90,7 @@ class SecuritySpec extends PlaySpecification {
   case class Connection(name: String)
 
   def withApplication[T](block: Application => T) = {
-    running(_.configure("play.http.secret.key" -> "foobar"))(block)
+    running(_.configure("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))(block)
   }
 }
 

--- a/core/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -118,7 +118,7 @@ class ScalaResultsSpec extends PlaySpecification {
 
   def withApplication[T](config: (String, Any)*)(block: Application => T): T =
     running(
-      _.configure(Map(config: _*) + ("play.http.secret.key" -> "foo"))
+      _.configure(Map(config: _*) + ("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
     )(block)
 
   def withFooDomain[T](block: Application => T) = withApplication("play.http.session.domain" -> ".foo.com")(block)

--- a/core/play-integration-test/src/test/scala/play/it/http/SessionCookieSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/SessionCookieSpec.scala
@@ -72,7 +72,7 @@ trait SessionCookieSpec extends PlaySpecification with ServerIntegrationSpecific
 
     "honor configuration for play.http.session.secure" in {
       "configured to true" in Helpers.running(_.configure("play.http.session.secure" -> true)) { _ =>
-        val secretConfiguration = SecretConfiguration()
+        val secretConfiguration = SecretConfiguration(secret = "vQU@MgnjTohP?w>jpu?X0oqvmz21o[AHP;/rPj?CB><YMFcl?xXfq]6o>1QuNcXU")
         val sessionCookieBaker: SessionCookieBaker = new DefaultSessionCookieBaker(
           SessionConfiguration(secure = true),
           secretConfiguration,
@@ -82,7 +82,7 @@ trait SessionCookieSpec extends PlaySpecification with ServerIntegrationSpecific
       }
 
       "configured to false" in Helpers.running(_.configure("play.http.session.secure" -> false)) { _ =>
-        val secretConfiguration = SecretConfiguration()
+        val secretConfiguration = SecretConfiguration(secret = "vQU@MgnjTohP?w>jpu?X0oqvmz21o[AHP;/rPj?CB><YMFcl?xXfq]6o>1QuNcXU")
         val sessionCookieBaker: SessionCookieBaker = new DefaultSessionCookieBaker(
           SessionConfiguration(secure = false),
           secretConfiguration,

--- a/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -4,11 +4,14 @@
 
 package play.api.http
 
+import java.nio.charset.StandardCharsets
+
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
 
 import com.typesafe.config.ConfigMemorySize
+import io.jsonwebtoken.SignatureAlgorithm
 import org.apache.commons.codec.digest.DigestUtils
 import play.api._
 import play.api.mvc.Cookie.SameSite
@@ -64,6 +67,9 @@ case class HttpConfiguration(
  * based on the location of application.conf.  This should be stable across restarts for a given application.
  *
  * To achieve 4, using the location of application.conf to generate the secret should ensure this.
+ *
+ * Play secret is checked for a minimum length, dependent on the algorithm used to sign the session and flash cookie.
+ * If the key has fewer bits then required by the algorithm, then an error is thrown and the configuration is invalid.
  *
  * @param secret   the application secret
  * @param provider the JCE provider to use. If null, uses the platform default
@@ -192,6 +198,8 @@ object HttpConfiguration {
       throw config.globalError("mimetype replaced by play.http.fileMimeTypes map")
     }
 
+    val secretConfiguration = getSecretConfiguration(config, environment)
+
     HttpConfiguration(
       context = context,
       parser = ParserConfiguration(
@@ -217,7 +225,7 @@ object HttpConfiguration {
         domain = config.getDeprecated[Option[String]]("play.http.session.domain", "session.domain"),
         sameSite = parseSameSite(config, "play.http.session.sameSite"),
         path = sessionPath,
-        jwt = JWTConfigurationParser(config, "play.http.session.jwt")
+        jwt = JWTConfigurationParser(config, secretConfiguration, "play.http.session.jwt")
       ),
       flash = FlashConfiguration(
         cookieName = config.getDeprecated[String]("play.http.flash.cookieName", "flash.cookieName"),
@@ -226,7 +234,7 @@ object HttpConfiguration {
         domain = config.get[Option[String]]("play.http.flash.domain"),
         sameSite = parseSameSite(config, "play.http.flash.sameSite"),
         path = flashPath,
-        jwt = JWTConfigurationParser(config, "play.http.flash.jwt")
+        jwt = JWTConfigurationParser(config, secretConfiguration, "play.http.flash.jwt")
       ),
       fileMimeTypes = FileMimeTypesConfiguration(
         config
@@ -247,7 +255,7 @@ object HttpConfiguration {
             }
           }(scala.collection.breakOut)
       ),
-      secret = getSecretConfiguration(config, environment)
+      secret = secretConfiguration
     )
   }
 
@@ -271,7 +279,8 @@ object HttpConfiguration {
             // No application.conf?  Oh well, just use something hard coded.
             "she sells sea shells on the sea shore"
           )(_.toString)
-          val md5Secret = DigestUtils.md5Hex(secret)
+          // We want 64 bytes / 512 bits to support HS512 so we append a second md5
+          val md5Secret = DigestUtils.md5Hex(secret) + DigestUtils.md5Hex("the shells she sells are sea-shells")
           logger.debug(
             s"Generated dev mode secret $md5Secret for app at ${appConfLocation.getOrElse("unknown location")}"
           )
@@ -354,12 +363,34 @@ case class JWTConfiguration(
 )
 
 object JWTConfigurationParser {
-  def apply(config: Configuration, parent: String): JWTConfiguration = {
+  def apply(config: Configuration, secretConfiguration: SecretConfiguration, parent: String): JWTConfiguration = {
     JWTConfiguration(
-      signatureAlgorithm = config.get[String](s"${parent}.signatureAlgorithm"),
+      signatureAlgorithm = getSignatureAlgorithm(config, secretConfiguration, parent),
       expiresAfter = config.get[Option[FiniteDuration]](s"${parent}.expiresAfter"),
       clockSkew = config.get[FiniteDuration](s"${parent}.clockSkew"),
       dataClaim = config.get[String](s"${parent}.dataClaim")
     )
+  }
+
+  private def getSignatureAlgorithm(
+      config: Configuration,
+      secretConfiguration: SecretConfiguration,
+      parent: String
+  ): String = {
+    val signatureAlgorithmPath      = s"${parent}.signatureAlgorithm"
+    System.out.println("looking for " + signatureAlgorithmPath)
+    val signatureAlgorithm          = config.get[String](signatureAlgorithmPath)
+    val minKeyLengthBits            = SignatureAlgorithm.forName(signatureAlgorithm).getMinKeyLength
+    val applicationSecretLengthBits = secretConfiguration.secret.getBytes(StandardCharsets.UTF_8).length * 8
+    if (applicationSecretLengthBits < minKeyLengthBits) {
+      val message =
+        s"""
+           |The application secret is too short and does not have the recommended amount of entropy for algorithm $signatureAlgorithm defined at $signatureAlgorithmPath.
+           |Current application secret bits: $applicationSecretLengthBits, minimal required bits for algorithm $signatureAlgorithm: $minKeyLengthBits.
+           |To set the application secret, please read https://playframework.com/documentation/latest/ApplicationSecret
+           |""".stripMargin
+      throw config.reportError("play.http.secret.key", message)
+    }
+    signatureAlgorithm
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -4,6 +4,8 @@
 
 package play.api.mvc
 
+import com.fasterxml.jackson.databind.ObjectMapper
+
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -11,8 +13,12 @@ import java.util.Base64
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
+import javax.crypto.spec.SecretKeySpec
+import javax.crypto.SecretKey
 
 import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.jackson.io.JacksonDeserializer
+import io.jsonwebtoken.jackson.io.JacksonSerializer
 import play.api.MarkerContexts.SecurityMarkerContext
 import play.api._
 import play.api.http._
@@ -646,7 +652,7 @@ trait JWTCookieDataCodec extends CookieDataCodec {
         logger.warn(s"decode: expired JWT found! id = $id, message = ${e.getMessage}")(SecurityMarkerContext)
         Map.empty
 
-      case e: io.jsonwebtoken.SignatureException =>
+      case e: security.SignatureException =>
         // Thrown when an invalid cookie signature is found -- this can be confusing to end users
         // so give a special logging message to indicate problem.
 
@@ -674,6 +680,8 @@ trait JWTCookieDataCodec extends CookieDataCodec {
 
 object JWTCookieDataCodec {
 
+  private val objectMapper: ObjectMapper = new ObjectMapper()
+
   /**
    * Maps to and from JWT claims.  This class is more basic than the JWT
    * cookie signing, because it exposes all claims, not just the "data" ones.
@@ -690,15 +698,18 @@ object JWTCookieDataCodec {
     import io.jsonwebtoken._
     import scala.collection.JavaConverters._
 
-    private val jwtClock = new io.jsonwebtoken.Clock {
+    private val jwtClock = new Clock {
       override def now(): Date = java.util.Date.from(clock.instant())
     }
 
-    private val base64EncodedSecret: String = {
-      Base64.getEncoder.encodeToString(
-        secretConfiguration.secret.getBytes(StandardCharsets.UTF_8)
-      )
-    }
+    private val signatureAlgorithm = SignatureAlgorithm.forName(jwtConfiguration.signatureAlgorithm)
+
+    private val secretKey: SecretKey = new SecretKeySpec(
+      secretConfiguration.secret.getBytes(StandardCharsets.UTF_8),
+      signatureAlgorithm.getJcaName
+    )
+
+
 
     /**
      * Parses encoded JWT against configuration, returns all JWT claims.
@@ -710,9 +721,11 @@ object JWTCookieDataCodec {
       val jws: Jws[Claims] = Jwts
         .parser()
         .setClock(jwtClock)
-        .setSigningKey(base64EncodedSecret)
+        .setSigningKey(secretKey)
         .setAllowedClockSkewSeconds(jwtConfiguration.clockSkew.toSeconds)
-        .parseClaimsJws(encodedString)
+        .deserializeJsonWith(new JacksonDeserializer(objectMapper))
+        .build()
+        .parseSignedClaims(encodedString)
 
       val headerAlgorithm = jws.getHeader.getAlgorithm
       if (headerAlgorithm != jwtConfiguration.signatureAlgorithm) {
@@ -731,7 +744,7 @@ object JWTCookieDataCodec {
      * @return the signed, encoded JWT with extra date related claims
      */
     def format(claims: Map[String, AnyRef]): String = {
-      val builder = Jwts.builder()
+      val builder = Jwts.builder().serializeToJsonWith(new JacksonSerializer(objectMapper))
       val now     = jwtClock.now()
 
       // Add the claims one at a time because it saves problems with mutable maps
@@ -751,8 +764,10 @@ object JWTCookieDataCodec {
       builder.setIssuedAt(now)  // https://tools.ietf.org/html/rfc7519#section-4.1.6
 
       // Sign and compact into a string...
-      val sigAlg = SignatureAlgorithm.valueOf(jwtConfiguration.signatureAlgorithm)
-      builder.signWith(sigAlg, base64EncodedSecret).compact()
+      // Even though secretKey already knows about the algorithm we have to pass signatureAlgorithm separately as well again.
+      // If not passing it, JJWT would try to determine the algorithm from the secretKey bit length via SignatureAlgorithm.forSigningKey(...)
+      // That would be a problem when e.g. in app conf HS256 is set (the default), but the secret has >= 64 bytes, then JJWT would choose HS512.
+      builder.signWith(secretKey, signatureAlgorithm).compact()
     }
   }
 

--- a/core/play/src/test/resources/reference.conf
+++ b/core/play/src/test/resources/reference.conf
@@ -3,7 +3,6 @@
 play {
   http {
     secret {
-      key = "a test secret"
     }
   }
 }

--- a/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -54,8 +54,8 @@ class HttpConfigurationSpec extends Specification {
         "play.http.flash.jwt.clockSkew"                               -> "30s",
         "play.http.flash.jwt.dataClaim"                               -> "data",
         "play.http.fileMimeTypes"                                     -> "foo=text/foo",
-        "play.http.secret.key"                                        -> "mysecret",
-        "play.http.secret.provider"                                   -> "HmacSHA1"
+        "play.http.secret.key"                                        -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b",
+        "play.http.secret.provider"                                   -> null
       )
     }
 

--- a/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
+++ b/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
@@ -17,11 +17,12 @@ class ActualKeySecretConfigurationParserSpec extends SecretConfigurationParserSp
 class DeprecatedKeySecretConfigurationParserSpec extends SecretConfigurationParserSpec {
   override def secretKey: String = "play.crypto.secret"
 
-  override def parseSecret(mode: Mode, secret: Option[String] = None) = {
+  override def parseSecret(mode: Mode, secret: Option[String] = None, flashJWTAlgorithm: Option[String] = None) = {
     HttpConfiguration
-      .fromConfiguration(
-        Configuration.reference ++ Configuration.from(
-          secret.map(secretKey -> _).toMap ++ Map(
+    .fromConfiguration(
+        Configuration.reference
+        ++ Configuration.from(
+          secret.map(secretKey -> _).toMap ++ flashJWTAlgorithm.map(flashCookieAlgorithm -> _).toMap ++ Map(
             "play.http.secret.key" -> null
           )
         ),
@@ -36,15 +37,19 @@ class DeprecatedKeySecretConfigurationParserSpec extends SecretConfigurationPars
 trait SecretConfigurationParserSpec extends Specification {
 
   def secretKey: String
+  def flashCookieAlgorithm: String = "play.http.flash.jwt.signatureAlgorithm"
 
-  val Secret = "abcdefghijklmnopqrs"
+  val Secret32Bytes = "abcdefghijklmnopqrstuvwxyz123456" // => 256 bits, required for HS256 (the default algorithm)
+  val Secret31Bytes = "abcdefghijklmnopqrstuvwxyz12345"  // => 248 bits, too short for HS256
 
-  def parseSecret(mode: Mode, secret: Option[String] = None): String = {
+  val Secret = Secret32Bytes
+
+  def parseSecret(mode: Mode, secret: Option[String] = None, flashJWTAlgorithm: Option[String] = None): String = {
     HttpConfiguration
-      .fromConfiguration(
-        Configuration.reference ++ Configuration.from(
-          secret.map(secretKey -> _).toMap
-        ),
+    .fromConfiguration(
+        Configuration.reference
+        ++ Configuration
+          .from(secret.map(secretKey -> _).toMap ++ flashJWTAlgorithm.map(flashCookieAlgorithm -> _).toMap),
         Environment.simple(mode = mode)
       )
       .secret
@@ -86,6 +91,55 @@ trait SecretConfigurationParserSpec extends Specification {
       }
       "generate a stable secret in dev" in {
         parseSecret(Mode.Dev, Some("changeme")) must_!= "changeme"
+      }
+      "throw an exception if secret is too short in prod" in {
+        parseSecret(Mode.Prod, Some(Secret31Bytes)) must throwA[PlayException].like {
+          case e =>
+            e.getMessage must beEqualTo(
+              """Configuration error[
+                |The application secret is too short and does not have the recommended amount of entropy for algorithm HS256 defined at play.http.session.jwt.signatureAlgorithm.
+                |Current application secret bits: 248, minimal required bits for algorithm HS256: 256.
+                |To set the application secret, please read https://playframework.com/documentation/latest/ApplicationSecret
+                |]""".stripMargin
+            )
+        }
+      }
+      "throw an exception if secret is too short in dev" in {
+        parseSecret(Mode.Dev, Some(Secret31Bytes)) must throwA[PlayException].like {
+          case e =>
+            e.getMessage must beEqualTo(
+              """Configuration error[
+                |The application secret is too short and does not have the recommended amount of entropy for algorithm HS256 defined at play.http.session.jwt.signatureAlgorithm.
+                |Current application secret bits: 248, minimal required bits for algorithm HS256: 256.
+                |To set the application secret, please read https://playframework.com/documentation/latest/ApplicationSecret
+                |]""".stripMargin
+            )
+        }
+      }
+      "throw an exception if secret is ok for session cookie but too short for flash cookie in prod" in {
+        System.out.println("running with 512")
+        parseSecret(Mode.Prod, Some(Secret32Bytes), flashJWTAlgorithm = Some("HS512")) must throwA[PlayException].like {
+          case e =>
+            e.getMessage must beEqualTo(
+              """Configuration error[
+                |The application secret is too short and does not have the recommended amount of entropy for algorithm HS512 defined at play.http.flash.jwt.signatureAlgorithm.
+                |Current application secret bits: 256, minimal required bits for algorithm HS512: 512.
+                |To set the application secret, please read https://playframework.com/documentation/latest/ApplicationSecret
+                |]""".stripMargin
+            )
+        }
+      }
+      "throw an exception if secret is ok for session cookie but too short for flash cookie in dev" in {
+        parseSecret(Mode.Dev, Some(Secret32Bytes), flashJWTAlgorithm = Some("HS512")) must throwA[PlayException].like {
+          case e =>
+            e.getMessage must beEqualTo(
+              """Configuration error[
+                |The application secret is too short and does not have the recommended amount of entropy for algorithm HS512 defined at play.http.flash.jwt.signatureAlgorithm.
+                |Current application secret bits: 256, minimal required bits for algorithm HS512: 512.
+                |To set the application secret, please read https://playframework.com/documentation/latest/ApplicationSecret
+                |]""".stripMargin
+            )
+        }
       }
     }
   }

--- a/core/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -198,7 +198,7 @@ class CookiesSpec extends Specification {
   }
 
   class TestJWTCookieDataCodec extends JWTCookieDataCodec {
-    val secretConfiguration                           = SecretConfiguration()
+    val secretConfiguration                           = SecretConfiguration(secret = "vQU@MgnjTohP?w>jpu?X0oqvmz21o[AHP;/rPj?CB><YMFcl?xXfq]6o>1QuNcXU")
     val jwtConfiguration                              = JWTConfiguration()
     protected override def uniqueId(): Option[String] = None
     override val clock                                = java.time.Clock.fixed(Instant.ofEpochMilli(0), ZoneId.of("UTC"))
@@ -210,13 +210,13 @@ class CookiesSpec extends Specification {
     "encode map to string" in {
       val jwtValue = codec.encode(Map("hello" -> "world"))
       jwtValue must beEqualTo(
-        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImhlbGxvIjoid29ybGQifSwibmJmIjowLCJpYXQiOjB9.mQUJopezrr3EC9gn_sB4XMb0ahvVq5F3tTB1shH0UOk"
+        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImhlbGxvIjoid29ybGQifSwibmJmIjowLCJpYXQiOjB9.D4VQdyi9iyT0zwCNOaIJ1tYTtLZd03dktWbaqP6OkSA"
       )
     }
 
     "decode string to map" in {
       val jwtValue =
-        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImhlbGxvIjoid29ybGQifSwibmJmIjowLCJpYXQiOjB9.mQUJopezrr3EC9gn_sB4XMb0ahvVq5F3tTB1shH0UOk"
+        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImhlbGxvIjoid29ybGQifSwibmJmIjowLCJpYXQiOjB9.D4VQdyi9iyT0zwCNOaIJ1tYTtLZd03dktWbaqP6OkSA"
       codec.decode(jwtValue) must contain("hello" -> "world")
     }
 
@@ -318,7 +318,7 @@ class CookiesSpec extends Specification {
 
     "decode a JWT cookie encoding" in {
       val signedEncoding =
-        "eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjAsImlhdCI6MCwiZGF0YSI6eyJoZWxsbyI6IndvcmxkIn19.SoN8DSDXnFSK0oZXs6hsP4y_8MQqiWQAPJYiTNfAErM"
+        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImhlbGxvIjoid29ybGQifSwibmJmIjowLCJpYXQiOjB9.D4VQdyi9iyT0zwCNOaIJ1tYTtLZd03dktWbaqP6OkSA"
       sessionCookieBaker.decode(signedEncoding) must contain("hello" -> "world")
     }
 
@@ -333,7 +333,7 @@ class CookiesSpec extends Specification {
 
     "encode to JWT" in {
       val jwtEncoding =
-        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImhlbGxvIjoid29ybGQifSwibmJmIjowLCJpYXQiOjB9.mQUJopezrr3EC9gn_sB4XMb0ahvVq5F3tTB1shH0UOk"
+        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImhlbGxvIjoid29ybGQifSwibmJmIjowLCJpYXQiOjB9.D4VQdyi9iyT0zwCNOaIJ1tYTtLZd03dktWbaqP6OkSA"
       sessionCookieBaker.encode(Map("hello" -> "world")) must beEqualTo(jwtEncoding)
     }
   }

--- a/core/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
@@ -7,6 +7,9 @@ package play.api.mvc
 import java.net.URLEncoder
 
 import org.specs2.specification.core.Fragments
+import play.api.http.FlashConfiguration
+import play.api.http.SecretConfiguration
+import play.api.libs.crypto.CookieSignerProvider
 
 class FlashCookieSpec extends org.specs2.mutable.Specification {
   "Flash cookies" should {
@@ -130,5 +133,13 @@ class FlashCookieSpec extends org.specs2.mutable.Specification {
     )
   }
 
-  def flash: FlashCookieBaker = new DefaultFlashCookieBaker()
+  def flash: FlashCookieBaker = {
+    val secretConfiguration =
+      SecretConfiguration(secret = "vQU@MgnjTohP?w>jpu?X0oqvmz21o[AHP;/rPj?CB><YMFcl?xXfq]6o>1QuNcXU")
+    new DefaultFlashCookieBaker(
+      FlashConfiguration(),
+      secretConfiguration,
+      new CookieSignerProvider(secretConfiguration).get
+    )
+  }
 }

--- a/persistence/play-jdbc/src/test/resources/application.conf
+++ b/persistence/play-jdbc/src/test/resources/application.conf
@@ -1,4 +1,4 @@
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 
 # Necessary when running tests using DEV or PROD mode.
-play.http.secret.key=dummy
+play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,11 +57,13 @@ object Dependencies {
 
   val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.9"
 
-  val jjwt = "io.jsonwebtoken" % "jjwt" % "0.7.0"
-  // currently jjwt needs the JAXB Api package in JDK 9+
-  // since it actually uses javax/xml/bind/DatatypeConverter
-  // See: https://github.com/jwtk/jjwt/issues/317
-  val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1"
+  val jjwtVersion = "0.13.0"
+  val jjwts       = Seq(
+      "io.jsonwebtoken" % "jjwt-api",
+      "io.jsonwebtoken" % "jjwt-impl"
+    ).map(_ % jjwtVersion) ++ Seq(
+      ("io.jsonwebtoken" % "jjwt-jackson" % jjwtVersion).excludeAll(ExclusionRule("com.fasterxml.jackson.core"))
+    )
 
   val jdbcDeps = Seq(
     "com.jolbox"         % "bonecp" % "0.8.0.RELEASE",
@@ -136,12 +138,11 @@ object Dependencies {
       Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % akkaVersion) ++
       Seq("akka-testkit").map("com.typesafe.akka"             %% _ % akkaVersion % Test) ++
       jacksons ++
+      jjwts++
       Seq(
         "commons-codec" % "commons-codec" % "1.11",
         playJson,
         guava,
-        jjwt,
-        jaxbApi,
         "org.apache.commons" % "commons-lang3" % "3.6",
         "javax.transaction"  % "jta"           % "1.1",
         "javax.inject"       % "javax.inject"  % "1",

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -28,10 +28,12 @@ class ServerResultUtilsSpec extends Specification {
 
   val jwtCodec = new JWTCookieDataCodec {
     override def jwtConfiguration    = JWTConfiguration()
-    override def secretConfiguration = SecretConfiguration()
+    override def secretConfiguration = SecretConfiguration(secret = "vQU@MgnjTohP?w>jpu?X0oqvmz21o[AHP;/rPj?CB><YMFcl?xXfq]6o>1QuNcXU")
   }
   val resultUtils = {
-    val httpConfig = HttpConfiguration()
+    val httpConfig = HttpConfiguration(secret =
+      SecretConfiguration(secret = "vQU@MgnjTohP?w>jpu?X0oqvmz21o[AHP;/rPj?CB><YMFcl?xXfq]6o>1QuNcXU")
+    )
     new ServerResultUtils(
       new DefaultSessionCookieBaker(
         httpConfig.session,

--- a/web/play-filters-helpers/src/test/resources/application.conf
+++ b/web/play-filters-helpers/src/test/resources/application.conf
@@ -1,6 +1,6 @@
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 
-play.http.secret.key= "abc"
+play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
 
 play.http.filters=play.api.http.NoHttpFilters
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -33,7 +33,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
 
   val TokenName     = "csrfToken"
   val HeaderName    = "Csrf-Token"
-  val CRYPTO_SECRET = "foobar"
+  val CRYPTO_SECRET = "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"
 
   def inject[T: ClassTag](implicit app: Application) = app.injector.instanceOf[T]
 
@@ -380,7 +380,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       config: Seq[(String, String)]
   )(router: PartialFunction[(String, String), Handler])(block: WSClient => T) = {
     implicit val app = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "foobar"))
+      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> CRYPTO_SECRET))
       .routes(router)
       .build()
     val ws = inject[WSClient]
@@ -391,7 +391,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       config: Seq[(String, String)]
   )(router: Application => PartialFunction[(String, String), Handler])(block: WSClient => T) = {
     implicit val app = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "foobar"))
+      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> CRYPTO_SECRET))
       .appRoutes(app => router(app))
       .build()
     val ws = inject[WSClient]

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -184,7 +184,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
 
     val notBufferedFakeApp = GuiceApplicationBuilder()
       .configure(
-        "play.http.secret.key"              -> "foobar",
+        "play.http.secret.key"              -> CRYPTO_SECRET,
         "play.filters.csrf.body.bufferSize" -> "200",
         "play.http.filters"                 -> classOf[CsrfFilters].getName
       )


### PR DESCRIPTION
We have some apps pulling in newer versions of jjwt which has backward incompatible changes. This bumps the version to the latest.

Other than the method signature change from `Jwts.parser()` the major change is that the new version requires the secret key's number of bits to match the size of the algorithm being used. So a bunch of tests needed to be updated to handle that. I also ported over the code that checks the key size on startup and will fail startup if it's not long enough, along with the tests for that.

This mainly pulls changes from these PRs: [8720 - require minimum length for secret](https://github.com/playframework/playframework/pull/8720), and [10726 - upgrade to latest JJWT](https://github.com/playframework/playframework/pull/10726)